### PR TITLE
Add StackData: SaaS pricing datasets for competitive benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Here are a few frameworks to get your price right:
 - [Your guide to reverse trials](https://web.archive.org/web/20250814071651/https://www.growthunhinged.com/p/your-guide-to-reverse-trials)
 - [8 fundamentals about free trials for early stage PLG startups](https://www.mrrunlocked.com/p/free-trials-fundamentals)
 - [14 tactical ideas for selling annual plans](https://web.archive.org/web/20250725183608/https://www.growthunhinged.com/p/how-to-sell-annual-plans)
+- [StackData — SaaS Pricing Datasets](https://greg-rg-git.github.io/stackdata-store/) - Structured CSV/JSON datasets of competitor pricing tiers for 13+ B2B SaaS categories (CRM, email marketing, devtools, PM tools, accounting, AI/ML tools, and more). Useful for benchmarking your pricing against the market before committing to a model.
 
 <br/><br/><br/>
 


### PR DESCRIPTION
## What this adds

[StackData](https://greg-rg-git.github.io/stackdata-store/) — Structured CSV/JSON datasets of competitor pricing tiers for 13+ B2B SaaS categories (CRM, email marketing, devtools, PM tools, accounting, AI/ML tools, and more). Useful for benchmarking your pricing against the market before committing to a model.

**Added to:** Pricing section (as last item, per guidelines)

## Why it fits

This section helps founders figure out how to price their product. One of the hardest parts of that process is knowing what competitors are charging — StackData solves that directly. Rather than manually scraping 15 vendor pricing pages before a pricing sprint, you get a structured dataset with tier breakdowns and feature comparisons.

I've used it when positioning a B2B SaaS product: seeing the distribution of pricing across 20 competing CRM tools in a CSV made the pricing decision much more grounded.

## Categories covered

CRM, Email Marketing, PM Tools, DevTools, SaaS Marketing Stacks, AI/ML Tools, Accounting/Finance, E-Commerce, HR Tech, No-Code tools, Agency/Freelance Rates, Affiliate Programs, and Design/Creative tools.

Datasets include pricing tier structures, feature-level comparisons, and positioning data collected from publicly available sources.