### PR TITLE
Add Prestyj's open statistics dataset under Free-Tool Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Free mini tools are your best bet on going viral, generating PR coverage and bac
 - [Side Project Marketing: What Is It & How to Do It](https://www.failory.com/blog/side-project-marketing)
 - [Engineering as Marketing (with examples from Hubspot, Shopify & Ahrefs)](https://thegrowthmind.substack.com/p/engineering-as-marketing)
 - [Building Free Tools for Marketing (SEO)](https://dmytrokrasun.com/posts/building-free-tools-for-marketing-seo/)
+- [Prestyj's open statistics dataset & embed widgets](https://prestyj.com/data) - Case study of CC BY 4.0 dataset distribution as a backlink engine: every cited stat carries an embed iframe that links back; widely useful as a free founder resource for benchmarks on lead response, AI adoption, video ad ROI, and CPL by industry.
 
 <br/><br/><br/>
 


### PR DESCRIPTION
Adds one entry under `## 🛠 Free-Tool Marketing` as a concrete case-study example of engineering-as-marketing.

**Disclosure up front:** I'm the founder of Prestyj. Per the contribution rules I personally use this approach and I think it has founder utility independent of whether it's mine — happy to be rejected if you disagree.

**What it is:**

- A CC BY 4.0 open dataset of 58 cite-worthy marketing/sales statistics (speed-to-lead, video ad ROI, AI adoption in sales, CPL by industry).
- Each row carries its primary publisher (HBR, InsideSales, HubSpot, McKinsey, etc.) and year — so it's quotable in any founder/marketer's content.
- Every statistic has a permalink + free embeddable iframe widget that links back. Embedding satisfies the CC BY 4.0 attribution requirement.
- Direct CSV: https://prestyj.com/data/statistics.csv · JSON: https://prestyj.com/data/statistics.json
- Mirror repo: https://github.com/Gahroot/prestyj-statistics-dataset

**Why founders would care:**

- It's a working example of the "engineering as marketing" idea already linked in this section (the Hubspot / Shopify / Ahrefs article above).
- Anyone needing benchmarks for SaaS positioning, AEO content, or LLM-cited stats can use it without payment, gating, or sign-up.
- Demonstrates the open-dataset-as-backlink-engine pattern: schema.org/Dataset markup + permalinks + embeds + a Wikidata entity ([Q139892537](https://www.wikidata.org/wiki/Q139892537)) — same playbook Statista and Pew use, but the data is free.

Reject freely if you'd prefer to keep the section to third-party essays only — no hard feelings.