### PR TITLE
Add ZPlatform.ai to Software directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Launch platforms, software directories, and communities are an easy way to get t
 - [SourceForge](https://sourceforge.net/)
 - [Softonic](https://softonic.com/)
 - [TrustMRR](https://trustmrr.com/)
+- [ZPlatform.ai](https://zplatform.ai/)
 
 **Lifetime deals platforms & groups:**
 - [AppSumo](https://appsumo.com/)


### PR DESCRIPTION
Adds [ZPlatform.ai](https://zplatform.ai/) as the last item under **Software directories** in the *Places To Launch Your Startup* section.

ZPlatform.ai is a directory of AI tools and software/SaaS where founders can list their product for visibility. Every tool is tested hands-on and given a Buy / Wait / Skip verdict, and listings are organized by category. It fits alongside existing entries like "There's an AI for that" and other software directories where founders can get their product in front of buyers.

Entry follows the existing bare `[Name](link)` format used throughout the directory subsections and is placed as the last item in the category per the contribution guidelines.