### PR TITLE
Add SmartBizCalc as real-world engineering-as-marketing case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ Free mini tools are your best bet on going viral, generating PR coverage and bac
 - [Side Project Marketing: What Is It & How to Do It](https://www.failory.com/blog/side-project-marketing)
 - [Engineering as Marketing (with examples from Hubspot, Shopify & Ahrefs)](https://thegrowthmind.substack.com/p/engineering-as-marketing)
 - [Building Free Tools for Marketing (SEO)](https://dmytrokrasun.com/posts/building-free-tools-for-marketing-seo/)
+- [SmartBizCalc — 292 free business calculators as engineering-as-marketing](https://smartbizcalc.com/) — Solo-built 292 free tools (break-even, LLC cost, startup cost, payroll tax, and more); drives organic traffic with zero paid acquisition.
 
 <br/><br/><br/>
 


### PR DESCRIPTION
SmartBizCalc (https://smartbizcalc.com) is a real-world example of the engineering-as-marketing playbook: 292 free business calculators built by one person, driving organic traffic with zero paid acquisition.

Added to the Free-Tool Marketing section as a practical case study alongside the existing resources.